### PR TITLE
Create Short.io URL shortener dashboard

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,8 @@
+# Short.io API Key，可在帳號後台的 Integrations > API 取得
+SHORT_IO_API_KEY=sk_your_api_key_here
+
+# 想要使用的短網址網域（例如：example.short.gy 或自訂網域）
+SHORT_IO_DOMAIN=example.short.gy
+
+# 可選：伺服器監聽的埠號
+PORT=3000

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+.env
+npm-debug.log*
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -1,1 +1,78 @@
-# short_links_website
+# Short.io URL Shortener Dashboard
+
+這個專案提供一個簡單易用的短網址管理網站，透過 [Short.io](https://short.io) API 建立、瀏覽、查詢與刪除短網址。後端使用 Node.js 原生模組實作 API 代理層，前端則是純 HTML/CSS/JavaScript 單頁式介面，適合部署於任何支援 Node.js 的環境。
+
+## 功能特色
+
+- ✅ **建立短網址**：輸入原始網址，可選擇自訂路徑、標題與到期時間。
+- 🔍 **搜尋與篩選**：即時搜尋標題或原始網址。
+- 📋 **複製短網址**：一鍵複製生成的短連結。
+- 📈 **查看詳情**：顯示點擊次數、建立/更新時間等資訊。
+- 🗑️ **刪除短網址**：直接從介面移除不再使用的連結。
+- 🌐 **多語系友善**：介面採繁體中文，表單支援各種字元輸入。
+
+## 環境需求
+
+- Node.js 18 或更新版本（本專案使用 Node.js 20 測試）。
+- 一組有效的 Short.io API Key。
+- 已設定的 Short.io 網域（免費版亦可）。
+
+## 安裝與啟動
+
+1. 下載專案：
+
+   ```bash
+   git clone <repository-url>
+   cd short_links_website
+   ```
+
+2. 建立環境變數設定檔 `.env`：
+
+   ```ini
+   SHORT_IO_API_KEY=你的shortio-api-key
+   SHORT_IO_DOMAIN=你的短網址網域（例：example.short.gy）
+   PORT=3000 # 可選，預設 3000
+   ```
+
+   > `SHORT_IO_API_KEY` 與 `SHORT_IO_DOMAIN` 皆為必填。若你有使用自訂網域，請填寫完整網域名稱。
+
+3. 安裝相依套件（本專案僅使用 Node.js 原生模組，因此無需額外安裝。如需額外工具，可自行加入）。
+
+4. 啟動伺服器：
+
+   ```bash
+   npm start
+   ```
+
+5. 開啟瀏覽器前往 <http://localhost:3000> 即可使用。
+
+## 系統架構說明
+
+- `server.js`：
+  - 載入 `.env` 環境變數。
+  - 提供靜態檔案服務與 API 代理。
+  - 核心路由：
+    - `GET /api/links`：列出符合條件的短網址。
+    - `POST /api/links`：建立新的短網址。
+    - `GET /api/links/:id`：查詢短網址詳細資料。
+    - `DELETE /api/links/:id`：刪除指定短網址。
+- `public/`：前端靜態資源。
+  - `index.html`：主視覺與表單界面。
+  - `styles.css`：柔和漸層風格的 UI 設計。
+  - `app.js`：與後端 API 溝通、渲染資料、處理互動邏輯。
+
+## 開發與自訂
+
+- 若要加入更多 Short.io API 功能（例如 UTM 參數、A/B 測試等），可在 `server.js` 新增對應的 API 代理端點，再於前端呼叫。
+- 若需國際化支援，可在 `public/app.js` 建立多語系字串表並依使用者語系切換。
+- 目前僅使用瀏覽器 `fetch` 與 `navigator.clipboard` API，如需支援較舊的瀏覽器，建議加入 polyfill。
+
+## 注意事項
+
+- 本專案僅做為示範，部署前請確保伺服器具備 TLS 與身分驗證等安全措施。
+- 若你使用 Docker 或雲端平台部署，務必在環境變數中設定 `SHORT_IO_API_KEY` 與 `SHORT_IO_DOMAIN`。
+- Short.io API 有速率限制，請依照官方文件規劃使用策略。
+
+## 授權
+
+本專案採用 ISC License，歡迎自由修改與擴充。

--- a/package.json
+++ b/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "short_links_website",
+  "version": "1.0.0",
+  "description": "A minimal Short.io-powered URL shortener dashboard",
+  "main": "server.js",
+  "type": "module",
+  "scripts": {
+    "start": "node server.js"
+  },
+  "keywords": [
+    "short.io",
+    "url-shortener",
+    "dashboard"
+  ],
+  "author": "",
+  "license": "ISC"
+}

--- a/public/app.js
+++ b/public/app.js
@@ -1,0 +1,307 @@
+const form = document.getElementById('create-form');
+const messageEl = document.getElementById('form-message');
+const linksContainer = document.getElementById('links-container');
+const template = document.getElementById('link-template');
+const searchInput = document.getElementById('search');
+const refreshBtn = document.getElementById('refresh');
+const dialog = document.getElementById('dialog');
+const dialogTitle = document.getElementById('dialog-title');
+const dialogBody = document.getElementById('dialog-body');
+const dialogClose = document.getElementById('dialog-close');
+
+let currentLinks = [];
+let isLoading = false;
+
+form.addEventListener('submit', async (event) => {
+  event.preventDefault();
+  const formData = new FormData(form);
+  const payload = Object.fromEntries(formData.entries());
+
+  if (!payload.originalURL) {
+    showFormMessage('請輸入原始網址', true);
+    return;
+  }
+
+  try {
+    setFormDisabled(true);
+    showFormMessage('建立中，請稍候…');
+    const response = await fetch('/api/links', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    });
+
+    if (!response.ok) {
+      const data = await safeParseJSON(response);
+      throw new Error(data?.message || '建立短網址時發生錯誤');
+    }
+
+    const created = await response.json();
+    showFormMessage('建立成功！', false);
+    form.reset();
+    await fetchLinks();
+    focusLink(created?.idString || created?.id);
+  } catch (error) {
+    console.error(error);
+    showFormMessage(error.message || '建立短網址時發生未知錯誤', true);
+  } finally {
+    setFormDisabled(false);
+  }
+});
+
+refreshBtn.addEventListener('click', () => fetchLinks());
+searchInput.addEventListener('input', debounce(() => fetchLinks(), 400));
+linksContainer.addEventListener('click', handleLinkContainerClick);
+dialogClose.addEventListener('click', closeDialog);
+dialog.addEventListener('click', (event) => {
+  if (event.target === dialog) closeDialog();
+});
+
+document.addEventListener('keydown', (event) => {
+  if (event.key === 'Escape' && !dialog.hasAttribute('hidden')) {
+    closeDialog();
+  }
+});
+
+fetchLinks();
+
+async function fetchLinks() {
+  if (isLoading) return;
+  isLoading = true;
+  renderPlaceholder();
+
+  try {
+    const params = new URLSearchParams();
+    const search = searchInput.value.trim();
+    if (search) params.set('search', search);
+
+    const response = await fetch(`/api/links?${params.toString()}`);
+    if (!response.ok) {
+      const errorData = await safeParseJSON(response);
+      throw new Error(errorData?.message || '載入短網址列表失敗');
+    }
+    const data = await response.json();
+    currentLinks = Array.isArray(data?.links) ? data.links : data?.data || [];
+    renderLinks();
+  } catch (error) {
+    console.error(error);
+    renderError(error.message || '載入資料時發生未知錯誤');
+  } finally {
+    isLoading = false;
+  }
+}
+
+function renderLinks() {
+  linksContainer.innerHTML = '';
+
+  if (!currentLinks.length) {
+    const empty = document.createElement('p');
+    empty.className = 'empty-state';
+    empty.textContent = '目前沒有符合條件的短網址。';
+    linksContainer.appendChild(empty);
+    return;
+  }
+
+  currentLinks.forEach((link) => {
+    const node = template.content.firstElementChild.cloneNode(true);
+    const titleEl = node.querySelector('.link-title');
+    const shortEl = node.querySelector('.link-short');
+    const originalEl = node.querySelector('.link-original');
+    const createdEl = node.querySelector('.link-created');
+    const detailsSection = node.querySelector('.link-details');
+
+    node.dataset.linkId = link.idString || link.id;
+    titleEl.textContent = link.title || '未命名短網址';
+    const shortUrl = link.shortURL || link.shortUrl || composeShortUrl(link);
+    shortEl.textContent = shortUrl;
+    shortEl.dataset.href = shortUrl;
+    originalEl.textContent = link.originalURL || link.originalUrl;
+    createdEl.textContent = `建立於 ${formatDate(link.createdAt || link.created_at)}`;
+
+    const details = buildDetailsList(link);
+    const dl = detailsSection.querySelector('dl');
+    details.forEach(([label, value]) => {
+      const dt = document.createElement('dt');
+      dt.textContent = label;
+      const dd = document.createElement('dd');
+      dd.textContent = value;
+      dl.append(dt, dd);
+    });
+
+    linksContainer.appendChild(node);
+  });
+}
+
+function renderPlaceholder() {
+  linksContainer.innerHTML = '';
+  const skeleton = document.createElement('p');
+  skeleton.className = 'empty-state';
+  skeleton.textContent = '載入中…';
+  linksContainer.appendChild(skeleton);
+}
+
+function renderError(message) {
+  linksContainer.innerHTML = '';
+  const errorEl = document.createElement('p');
+  errorEl.className = 'empty-state';
+  errorEl.textContent = message;
+  linksContainer.appendChild(errorEl);
+}
+
+function setFormDisabled(disabled) {
+  Array.from(form.elements).forEach((el) => {
+    el.disabled = disabled;
+  });
+}
+
+function showFormMessage(message, isError = false) {
+  messageEl.textContent = message;
+  messageEl.className = isError ? 'error' : 'success';
+}
+
+async function handleLinkContainerClick(event) {
+  const action = event.target?.dataset?.action;
+  if (!action) return;
+
+  const article = event.target.closest('.link-item');
+  if (!article) return;
+  const linkId = article.dataset.linkId;
+
+  if (action === 'copy') {
+    const href = article.querySelector('[data-copy]')?.dataset?.href;
+    if (href) {
+      await navigator.clipboard.writeText(href);
+      showTemporaryToast(article, '已複製！');
+    }
+    return;
+  }
+
+  if (action === 'details') {
+    await toggleDetails(article, linkId);
+    return;
+  }
+
+  if (action === 'delete') {
+    if (!confirm('確定要刪除這個短網址嗎？')) return;
+    try {
+      const response = await fetch(`/api/links/${linkId}`, { method: 'DELETE' });
+      if (!response.ok && response.status !== 204) {
+        const data = await safeParseJSON(response);
+        throw new Error(data?.message || '刪除失敗');
+      }
+      await fetchLinks();
+    } catch (error) {
+      console.error(error);
+      showDialog('刪除失敗', error.message || '發生未知錯誤');
+    }
+    return;
+  }
+}
+
+async function toggleDetails(article, linkId) {
+  const section = article.querySelector('.link-details');
+  if (!section.hasAttribute('hidden')) {
+    section.setAttribute('hidden', '');
+    return;
+  }
+
+  try {
+    const response = await fetch(`/api/links/${linkId}`);
+    if (!response.ok) {
+      const data = await safeParseJSON(response);
+      throw new Error(data?.message || '取得短網址詳情失敗');
+    }
+    const data = await response.json();
+    const dl = section.querySelector('dl');
+    dl.innerHTML = '';
+    const details = buildDetailsList(data);
+    details.forEach(([label, value]) => {
+      const dt = document.createElement('dt');
+      dt.textContent = label;
+      const dd = document.createElement('dd');
+      dd.textContent = value;
+      dl.append(dt, dd);
+    });
+    section.removeAttribute('hidden');
+  } catch (error) {
+    console.error(error);
+    showDialog('載入詳情失敗', error.message || '發生未知錯誤');
+  }
+}
+
+function buildDetailsList(link) {
+  if (!link) return [];
+  const shortUrl = link.shortURL || link.shortUrl || composeShortUrl(link);
+  return [
+    ['短網址', shortUrl || '—'],
+    ['原始網址', link.originalURL || link.originalUrl || '—'],
+    ['標題', link.title || '—'],
+    ['唯一代號', link.idString || link.id || '—'],
+    ['建立時間', formatDate(link.createdAt || link.created_at)],
+    ['更新時間', formatDate(link.updatedAt || link.updated_at)],
+    ['總點擊數', link.clicks != null ? String(link.clicks) : '—'],
+    ['狀態', link.archived ? '已封存' : '使用中'],
+  ];
+}
+
+function composeShortUrl(link) {
+  const domain = link.domain || link.domain_id;
+  const secureShortUrl = link.secureShortURL || link.secureShortUrl;
+  if (secureShortUrl) return secureShortUrl;
+  if (!domain || !link.path) return '';
+  const protocol = link.secure ? 'https://' : 'http://';
+  return `${protocol}${domain}/${link.path}`;
+}
+
+function formatDate(input) {
+  if (!input) return '—';
+  const date = new Date(input);
+  if (Number.isNaN(date.getTime())) return input;
+  return date.toLocaleString();
+}
+
+function showDialog(title, body) {
+  dialogTitle.textContent = title;
+  dialogBody.textContent = body;
+  dialog.removeAttribute('hidden');
+}
+
+function closeDialog() {
+  dialog.setAttribute('hidden', '');
+}
+
+function showTemporaryToast(node, message) {
+  const toast = document.createElement('span');
+  toast.className = 'toast';
+  toast.textContent = message;
+  node.appendChild(toast);
+  setTimeout(() => {
+    toast.remove();
+  }, 1500);
+}
+
+function focusLink(linkId) {
+  if (!linkId) return;
+  const el = linksContainer.querySelector(`[data-link-id="${linkId}"]`);
+  if (el) {
+    el.scrollIntoView({ behavior: 'smooth', block: 'center' });
+    el.classList.add('highlight');
+    setTimeout(() => el.classList.remove('highlight'), 2000);
+  }
+}
+
+function debounce(fn, delay) {
+  let timer = null;
+  return (...args) => {
+    clearTimeout(timer);
+    timer = setTimeout(() => fn(...args), delay);
+  };
+}
+
+async function safeParseJSON(response) {
+  try {
+    return await response.json();
+  } catch (error) {
+    return null;
+  }
+}

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,87 @@
+<!DOCTYPE html>
+<html lang="zh-Hant">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>短網址管理控制台</title>
+    <link rel="stylesheet" href="/styles.css" />
+  </head>
+  <body>
+    <header class="app-header">
+      <h1>短網址管理控制台</h1>
+      <p>使用 Short.io API 建立與管理專屬短網址</p>
+    </header>
+
+    <main class="layout">
+      <section class="card">
+        <h2>建立短網址</h2>
+        <form id="create-form" class="form">
+          <label class="form-field">
+            <span>原始網址 *</span>
+            <input type="url" id="originalURL" name="originalURL" placeholder="https://example.com" required />
+          </label>
+          <label class="form-field">
+            <span>自訂路徑 (選填)</span>
+            <input type="text" id="path" name="path" placeholder="my-campaign" />
+          </label>
+          <label class="form-field">
+            <span>標題 (選填)</span>
+            <input type="text" id="title" name="title" placeholder="2025 春季活動" />
+          </label>
+          <label class="form-field">
+            <span>到期日 (選填)</span>
+            <input type="datetime-local" id="expiresAt" name="expiresAt" />
+          </label>
+          <button type="submit" class="primary-btn">建立短網址</button>
+        </form>
+        <div id="form-message" role="alert"></div>
+      </section>
+
+      <section class="card">
+        <div class="card-header">
+          <h2>短網址列表</h2>
+          <div class="search-group">
+            <input type="search" id="search" placeholder="搜尋標題或原始網址" />
+            <button id="refresh" class="secondary-btn">重新整理</button>
+          </div>
+        </div>
+        <div id="links-container" class="links-container" aria-live="polite">
+          <p class="empty-state">尚未載入資料，請點擊「重新整理」。</p>
+        </div>
+      </section>
+    </main>
+
+    <template id="link-template">
+      <article class="link-item">
+        <div class="link-header">
+          <div>
+            <h3 class="link-title"></h3>
+            <p class="link-short" data-copy></p>
+          </div>
+          <button class="icon-btn" data-action="copy" title="複製短網址">📋</button>
+        </div>
+        <p class="link-original"></p>
+        <footer class="link-footer">
+          <span class="link-created"></span>
+          <div class="link-actions">
+            <button class="secondary-btn" data-action="details">查看資訊</button>
+            <button class="danger-btn" data-action="delete">刪除</button>
+          </div>
+        </footer>
+        <section class="link-details" hidden>
+          <dl></dl>
+        </section>
+      </article>
+    </template>
+
+    <div id="dialog" class="dialog" hidden role="dialog" aria-modal="true" aria-labelledby="dialog-title">
+      <div class="dialog-content">
+        <h3 id="dialog-title"></h3>
+        <pre id="dialog-body"></pre>
+        <button id="dialog-close" class="primary-btn">關閉</button>
+      </div>
+    </div>
+
+    <script src="/app.js" type="module"></script>
+  </body>
+</html>

--- a/public/styles.css
+++ b/public/styles.css
@@ -1,0 +1,285 @@
+:root {
+  color-scheme: light dark;
+  font-family: 'Noto Sans TC', 'Segoe UI', sans-serif;
+  line-height: 1.5;
+  --bg: #f5f7fb;
+  --card: #ffffff;
+  --text: #222222;
+  --muted: #5f6c7b;
+  --primary: #2563eb;
+  --primary-text: #ffffff;
+  --border: #d8dee9;
+  --danger: #dc2626;
+}
+
+body {
+  margin: 0;
+  background: var(--bg);
+  color: var(--text);
+}
+
+.app-header {
+  padding: 2rem 3vw;
+  background: linear-gradient(135deg, #1e3a8a, #2563eb);
+  color: #fff;
+  text-align: center;
+}
+
+.layout {
+  display: grid;
+  gap: 2rem;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  padding: 2rem 3vw 4rem;
+  max-width: 1200px;
+  margin: 0 auto;
+}
+
+.card {
+  background: var(--card);
+  border-radius: 16px;
+  padding: 1.75rem;
+  box-shadow: 0 16px 40px rgba(15, 23, 42, 0.08);
+  border: 1px solid rgba(15, 23, 42, 0.05);
+}
+
+.card-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 1rem;
+}
+
+.form {
+  display: grid;
+  gap: 1rem;
+}
+
+.form-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.form-field input {
+  padding: 0.75rem 1rem;
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  font-size: 1rem;
+}
+
+.primary-btn,
+.secondary-btn,
+.danger-btn,
+.icon-btn {
+  cursor: pointer;
+  border: none;
+  border-radius: 999px;
+  font-weight: 600;
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+.primary-btn {
+  padding: 0.75rem 1.5rem;
+  background: var(--primary);
+  color: var(--primary-text);
+  box-shadow: 0 10px 20px rgba(37, 99, 235, 0.25);
+}
+
+.primary-btn:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 16px 30px rgba(37, 99, 235, 0.35);
+}
+
+.secondary-btn {
+  padding: 0.6rem 1.2rem;
+  background: rgba(37, 99, 235, 0.1);
+  color: var(--primary);
+}
+
+.secondary-btn:hover {
+  transform: translateY(-1px);
+}
+
+.danger-btn {
+  padding: 0.6rem 1.2rem;
+  background: rgba(220, 38, 38, 0.1);
+  color: var(--danger);
+}
+
+.danger-btn:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 12px 24px rgba(220, 38, 38, 0.25);
+}
+
+.icon-btn {
+  background: transparent;
+  font-size: 1.5rem;
+  padding: 0.3rem;
+}
+
+.links-container {
+  display: grid;
+  gap: 1rem;
+}
+
+.link-item {
+  background: rgba(37, 99, 235, 0.05);
+  border-radius: 16px;
+  padding: 1.25rem;
+  border: 1px solid rgba(37, 99, 235, 0.15);
+}
+
+.link-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: start;
+  gap: 0.75rem;
+}
+
+.link-title {
+  margin: 0;
+  font-size: 1.1rem;
+}
+
+.link-short {
+  margin: 0.35rem 0 0;
+  color: var(--primary);
+  font-weight: 600;
+  cursor: pointer;
+  word-break: break-all;
+}
+
+.link-original {
+  margin: 0.75rem 0 1rem;
+  color: var(--muted);
+  word-break: break-all;
+}
+
+.link-footer {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+  font-size: 0.9rem;
+  color: var(--muted);
+}
+
+.link-actions {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.link-details {
+  margin-top: 1rem;
+  background: #fff;
+  border-radius: 10px;
+  padding: 1rem;
+  border: 1px solid rgba(15, 23, 42, 0.08);
+}
+
+.link-details dl {
+  display: grid;
+  grid-template-columns: max-content 1fr;
+  gap: 0.5rem 1rem;
+  margin: 0;
+}
+
+.link-details dt {
+  font-weight: 600;
+}
+
+.empty-state {
+  color: var(--muted);
+}
+
+#form-message {
+  margin-top: 1rem;
+  min-height: 1.25rem;
+  font-weight: 600;
+}
+
+#form-message.error {
+  color: var(--danger);
+}
+
+#form-message.success {
+  color: var(--primary);
+}
+
+.search-group {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.search-group input {
+  flex: 1;
+  min-width: 160px;
+  padding: 0.65rem 1rem;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+}
+
+.dialog {
+  position: fixed;
+  inset: 0;
+  background: rgba(15, 23, 42, 0.35);
+  display: grid;
+  place-items: center;
+  padding: 2rem;
+}
+
+.dialog-content {
+  background: var(--card);
+  border-radius: 16px;
+  padding: 2rem;
+  width: min(90vw, 520px);
+  max-height: 80vh;
+  overflow: auto;
+  box-shadow: 0 20px 50px rgba(15, 23, 42, 0.3);
+}
+
+.dialog pre {
+  background: rgba(15, 23, 42, 0.05);
+  border-radius: 12px;
+  padding: 1rem;
+  white-space: pre-wrap;
+  word-break: break-all;
+}
+
+@media (max-width: 600px) {
+  .app-header {
+    padding: 1.75rem 1.5rem;
+  }
+
+  .layout {
+    padding: 1.5rem;
+  }
+}
+
+.toast {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  margin-left: 0.5rem;
+  padding: 0.2rem 0.6rem;
+  border-radius: 999px;
+  background: rgba(37, 99, 235, 0.15);
+  color: var(--primary);
+  font-size: 0.85rem;
+  font-weight: 600;
+}
+
+.highlight {
+  animation: highlight 2s ease-out;
+}
+
+@keyframes highlight {
+  0% {
+    box-shadow: 0 0 0 0 rgba(37, 99, 235, 0.5);
+  }
+  100% {
+    box-shadow: 0 0 0 20px rgba(37, 99, 235, 0);
+  }
+}

--- a/server.js
+++ b/server.js
@@ -1,0 +1,249 @@
+import http from 'node:http';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+function loadEnv() {
+  const envPath = path.join(__dirname, '.env');
+  if (!fs.existsSync(envPath)) {
+    return;
+  }
+
+  const lines = fs.readFileSync(envPath, 'utf8').split(/\r?\n/);
+  for (const line of lines) {
+    if (!line || line.startsWith('#')) continue;
+    const idx = line.indexOf('=');
+    if (idx === -1) continue;
+    const key = line.slice(0, idx).trim();
+    const value = line.slice(idx + 1).trim();
+    if (!(key in process.env)) {
+      process.env[key] = value;
+    }
+  }
+}
+
+loadEnv();
+
+const API_BASE_URL = 'https://api.short.io/api';
+const API_KEY = process.env.SHORT_IO_API_KEY;
+const SHORT_DOMAIN = process.env.SHORT_IO_DOMAIN;
+
+const server = http.createServer(async (req, res) => {
+  try {
+    const url = new URL(req.url, `http://${req.headers.host}`);
+    if (url.pathname.startsWith('/api/')) {
+      await handleApiRequest(req, res, url);
+    } else {
+      await serveStaticFile(res, url.pathname);
+    }
+  } catch (error) {
+    console.error(error);
+    res.writeHead(500, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ message: 'Internal server error' }));
+  }
+});
+
+async function serveStaticFile(res, pathname) {
+  const filePath = pathname === '/' ? '/index.html' : pathname;
+  const fullPath = path.join(__dirname, 'public', filePath);
+
+  if (!fullPath.startsWith(path.join(__dirname, 'public'))) {
+    res.writeHead(403);
+    res.end('Forbidden');
+    return;
+  }
+
+  try {
+    const data = await fs.promises.readFile(fullPath);
+    const ext = path.extname(fullPath).toLowerCase();
+    const contentType = getContentType(ext);
+    res.writeHead(200, { 'Content-Type': contentType });
+    res.end(data);
+  } catch (error) {
+    if (error.code === 'ENOENT') {
+      res.writeHead(404, { 'Content-Type': 'text/plain' });
+      res.end('Not Found');
+    } else {
+      throw error;
+    }
+  }
+}
+
+function getContentType(ext) {
+  switch (ext) {
+    case '.html':
+      return 'text/html; charset=utf-8';
+    case '.css':
+      return 'text/css; charset=utf-8';
+    case '.js':
+      return 'application/javascript; charset=utf-8';
+    case '.json':
+      return 'application/json; charset=utf-8';
+    default:
+      return 'application/octet-stream';
+  }
+}
+
+async function handleApiRequest(req, res, url) {
+  if (!API_KEY || !SHORT_DOMAIN) {
+    res.writeHead(500, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ message: 'Missing SHORT_IO_API_KEY or SHORT_IO_DOMAIN environment variables.' }));
+    return;
+  }
+
+  try {
+    if (req.method === 'GET' && url.pathname === '/api/health') {
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ status: 'ok' }));
+      return;
+    }
+
+    if (req.method === 'GET' && url.pathname === '/api/links') {
+      const search = url.searchParams.get('search') || '';
+      const limit = url.searchParams.get('limit') || '50';
+      const pageToken = url.searchParams.get('pageToken');
+
+      const queryParams = new URLSearchParams({
+        domain: SHORT_DOMAIN,
+        limit,
+      });
+      if (search) queryParams.set('search', search);
+      if (pageToken) queryParams.set('pageToken', pageToken);
+
+      const result = await shortIoRequest(`/links?${queryParams.toString()}`);
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify(result));
+      return;
+    }
+
+    if (req.method === 'POST' && url.pathname === '/api/links') {
+      const body = await readJsonBody(req);
+      if (!body || !body.originalURL) {
+        res.writeHead(400, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ message: 'originalURL is required' }));
+        return;
+      }
+
+      const payload = {
+        domain: SHORT_DOMAIN,
+        originalURL: body.originalURL,
+      };
+
+      if (body.title) payload.title = body.title;
+      if (body.path) payload.path = body.path;
+      if (body.redirectType) payload.redirectType = body.redirectType;
+      if (body.expiresAt) payload.expiresAt = body.expiresAt;
+
+      const result = await shortIoRequest('/links', {
+        method: 'POST',
+        body: payload,
+      });
+      res.writeHead(201, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify(result));
+      return;
+    }
+
+    const linkIdMatch = url.pathname.match(/^\/api\/links\/(.+)$/);
+    if (linkIdMatch) {
+      const linkId = linkIdMatch[1];
+
+      if (req.method === 'GET') {
+        const result = await shortIoRequest(`/links/${linkId}`);
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify(result));
+        return;
+      }
+
+      if (req.method === 'DELETE') {
+        await shortIoRequest(`/links/${linkId}`, { method: 'DELETE' });
+        res.writeHead(204).end();
+        return;
+      }
+    }
+
+    res.writeHead(404, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ message: 'Endpoint not found' }));
+  } catch (error) {
+    console.error('Short.io API error', error);
+    const status = error.status || (error instanceof SyntaxError ? 400 : 502);
+    const payload = {
+      message: error.data?.message || error.message || 'Short.io API request failed',
+    };
+    if (error instanceof SyntaxError) {
+      payload.message = 'Invalid JSON payload';
+    }
+    if (error.data && typeof error.data === 'object' && error.data !== null) {
+      payload.details = error.data;
+    } else if (typeof error.data === 'string') {
+      payload.details = { raw: error.data };
+    }
+    res.writeHead(status, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify(payload));
+  }
+}
+
+async function shortIoRequest(endpoint, options = {}) {
+  const url = `${API_BASE_URL}${endpoint}`;
+  const fetchOptions = {
+    method: options.method || 'GET',
+    headers: {
+      'Authorization': API_KEY,
+      'Content-Type': 'application/json',
+    },
+  };
+
+  if (options.body) {
+    fetchOptions.body = JSON.stringify(options.body);
+  }
+
+  const response = await fetch(url, fetchOptions);
+  const contentType = response.headers.get('content-type') || '';
+  let data = null;
+  if (contentType.includes('application/json')) {
+    data = await response.json();
+  } else {
+    data = await response.text();
+  }
+
+  if (!response.ok) {
+    const error = new Error('Short.io API error');
+    error.status = response.status;
+    error.data = data;
+    throw error;
+  }
+
+  return data;
+}
+
+function readJsonBody(req) {
+  return new Promise((resolve, reject) => {
+    let body = '';
+    req.on('data', chunk => {
+      body += chunk;
+      if (body.length > 1e6) {
+        req.connection.destroy();
+        reject(new Error('Payload too large'));
+      }
+    });
+    req.on('end', () => {
+      if (!body) {
+        resolve(null);
+        return;
+      }
+      try {
+        resolve(JSON.parse(body));
+      } catch (error) {
+        reject(error);
+      }
+    });
+    req.on('error', reject);
+  });
+}
+
+const PORT = process.env.PORT || 3000;
+server.listen(PORT, () => {
+  console.log(`Server running on http://localhost:${PORT}`);
+});


### PR DESCRIPTION
## Summary
- add a lightweight Node.js server that proxies the Short.io API and serves the static dashboard
- implement a client-side dashboard for creating, browsing, inspecting, copying, and deleting short links
- document environment setup and provide sample environment variables for Short.io credentials

## Testing
- node --check server.js

------
https://chatgpt.com/codex/tasks/task_e_68db2a6836e48323973207efc5774fa8